### PR TITLE
Update mock.go to call hooks that are added to mock client

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -93,11 +93,10 @@ func (h redisClientHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
 		err := h.fn(cmd)
 		if h.returnErr != nil && (err == nil || cmd.Err() == nil) {
-			err = h.returnErr
+			return h.returnErr
 		}
 
-		err = hook(ctx, cmd)
-		return err
+		return hook(ctx, cmd)
 	}
 }
 
@@ -113,8 +112,7 @@ func (h redisClientHook) ProcessPipelineHook(hook redis.ProcessPipelineHook) red
 			}
 		}
 
-		err := hook(ctx, cmds)
-		return err
+		return hook(ctx, cmds)
 	}
 }
 


### PR DESCRIPTION
After updating to go-redis-v9, I found that the hooks were not getting executed in tests. This change makes it so hooks that are added to the mock client are executed as expected, per https://uptrace.dev/blog/go-redis-v9.html#improved-hooks.