### PR TITLE
feat: Add SELECT command.

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -2469,6 +2469,16 @@ var _ = Describe("Commands", func() {
 			})
 		})
 
+		if c, ok := client.(*redis.Client); ok {
+			It("Save", func() {
+				operationStatusCmd(clientMock, func() *ExpectedStatus {
+					return clientMock.ExpectSelect(1)
+				}, func() *redis.StatusCmd {
+					return c.Conn().Select(ctx, 1)
+				})
+			})
+		}
+
 		It("Shutdown", func() {
 			//no test
 		})

--- a/expect.go
+++ b/expect.go
@@ -285,6 +285,7 @@ type baseMock interface {
 	ExpectInfo(section ...string) *ExpectedString
 	ExpectLastSave() *ExpectedInt
 	ExpectSave() *ExpectedStatus
+	ExpectSelect(index int) *ExpectedStatus
 	ExpectShutdown() *ExpectedStatus
 	ExpectShutdownSave() *ExpectedStatus
 	ExpectShutdownNoSave() *ExpectedStatus

--- a/mock.go
+++ b/mock.go
@@ -2187,6 +2187,13 @@ func (m *mock) ExpectSave() *ExpectedStatus {
 	return e
 }
 
+func (m *mock) ExpectSelect(index int) *ExpectedStatus {
+	e := &ExpectedStatus{}
+	e.cmd = redis.NewStatusCmd(m.ctx, "select", index)
+	m.pushExpect(e)
+	return e
+}
+
 func (m *mock) ExpectShutdown() *ExpectedStatus {
 	e := &ExpectedStatus{}
 	e.cmd = m.factory.Shutdown(m.ctx)


### PR DESCRIPTION
Depends on https://github.com/redis/go-redis/pull/2680.

Adds expectations for the SELECT command, which changes the connection's currently selected DB. Note that this only means anything on `redis.Client`s, not `redis.ClusterClient`.