### PR TITLE
Issue#83: fix compatibility issue with go-redis v9.2.0

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Commands", func() {
 	var (
 		clientMock baseMock
-		client     redis.Cmdable
+		client     mockCmdable
 		clientType redisClientType
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.25.0
-	github.com/redis/go-redis/v9 v9.0.3
+	github.com/redis/go-redis/v9 v9.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/onsi/gomega v1.25.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdM
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.0.3 h1:+7mmR26M0IvyLxGZUHxu4GiBkJkVDid0Un+j4ScYu4k=
 github.com/redis/go-redis/v9 v9.0.3/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
+github.com/redis/go-redis/v9 v9.2.0 h1:zwMdX0A4eVzse46YN18QhuDiM4uf3JmkOB4VZrdt5uI=
+github.com/redis/go-redis/v9 v9.2.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/mock.go
+++ b/mock.go
@@ -12,12 +12,18 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
+type mockCmdable interface {
+	redis.Cmdable
+	redis.BitMapCmdable
+	redis.StreamCmdable
+}
+
 type mock struct {
 	ctx context.Context
 
 	parent *mock
 
-	factory  redis.Cmdable
+	factory  mockCmdable
 	client   redis.Cmdable
 	expected []expectation
 


### PR DESCRIPTION
Also, update the dependency to be v9.2.0