### PR TITLE
fix: cmd error in pipelines

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -113,7 +113,7 @@ func (h redisClientHook) ProcessPipelineHook(_ redis.ProcessPipelineHook) redis.
 				err = h.returnErr
 			}
 			if err != nil {
-				return err
+				cmd.SetErr(err)
 			}
 		}
 		return nil


### PR DESCRIPTION
When a command in a pipeline produces an error, only this single command should fail and return an error.

However the currently implemented behavior is that the complete pipeline execution fails, which isn't resembling the behavior from Redis.

Example:
```golang

func toBeTested(redis *redis.Client) {
  pipe := redis.Pipeline()

  pipe.Get("key1")
  pipe.Get("key2")

  cmds, err := pipe.Exec()
  // The behavior of Redis is that `err=nil`, although the seconds command will return a `redis.Nil` error.
  // cmds[1].Err() should be `redis.Nil`
  // The redismock implemention however returns already here `redis.Nil` error, which is wrong behavior. 
}

func Test_1(t *testing.T) {
  redisClient, mock := redismock.NewClientMock()

  mock.ExpectGet("key1").SetVal("val1")
  mock.ExpectGet("key2").RedisNil()

  toBeTested(redisClient)
}
```